### PR TITLE
feat: adding vantage toolbar styling

### DIFF
--- a/src/lib/_theming.scss
+++ b/src/lib/_theming.scss
@@ -579,7 +579,7 @@ body {
   .mat-toolbar-row,
   .mat-toolbar-single-row,
   .mat-toolbar-multiple-rows,
-  .td-vantage-toolbar {
+  .vantage-toolbar {
     .mat-stroked-button,
     .mat-raised-button,
     .mat-flat-button,


### PR DESCRIPTION
Add class for td-vantage-toolbar, and refined css styling rules covering all mat button types to work consistently

Tested on Chrome, Firefox, Safari, Edge Dev