### PR TITLE
fix(): logout to redirect

### DIFF
--- a/src/docs-ui/app/main/main.component.ts
+++ b/src/docs-ui/app/main/main.component.ts
@@ -42,7 +42,7 @@ export class MainComponent implements OnInit {
     });
   }
 
-  async logout(): Promise<void> {
-    await this._sessionService.logout();
+  public logout(): void {
+    window.location.href = '/api/user/logout';
   }
 }

--- a/src/docs-ui/app/main/main.component.ts
+++ b/src/docs-ui/app/main/main.component.ts
@@ -43,6 +43,6 @@ export class MainComponent implements OnInit {
   }
 
   public logout(): void {
-    window.location.href = '/api/user/logout';
+    this._sessionService.logout();
   }
 }

--- a/src/lib/auth/guards/authentication.guard.ts
+++ b/src/lib/auth/guards/authentication.guard.ts
@@ -16,7 +16,7 @@ export class VantageAuthenticationGuard implements CanActivate {
     } catch (e) {
       // if not logged in, go ahead and log in...otherwise logout
       // append the current path so we get redirected back upon login
-      (e.status === UNAUTHORIZED) ? window.location.href = '/start-login' : this._sessionService.logout();
+      window.location.href = (e.status === UNAUTHORIZED) ? '/start-login' : '/api/user/logout';
       return false;
     }
     return true;

--- a/src/lib/auth/guards/authentication.guard.ts
+++ b/src/lib/auth/guards/authentication.guard.ts
@@ -16,7 +16,7 @@ export class VantageAuthenticationGuard implements CanActivate {
     } catch (e) {
       // if not logged in, go ahead and log in...otherwise logout
       // append the current path so we get redirected back upon login
-      window.location.href = (e.status === UNAUTHORIZED) ? '/start-login' : '/api/user/logout';
+      (e.status === UNAUTHORIZED) ? window.location.href = '/start-login' : this._sessionService.logout();
       return false;
     }
     return true;

--- a/src/lib/auth/session/session.service.ts
+++ b/src/lib/auth/session/session.service.ts
@@ -56,6 +56,10 @@ export class VantageSessionService {
     }
   }
 
+  public logout(): void {
+    window.location.href = '/api/user/logout';
+  }
+
   /**
    * gets the current sso logged in users information
    */

--- a/src/lib/auth/session/session.service.ts
+++ b/src/lib/auth/session/session.service.ts
@@ -56,17 +56,6 @@ export class VantageSessionService {
     }
   }
 
-  async logout(): Promise<void> {
-    try {
-      return await this._logout().toPromise();
-    } catch (e) {
-      // ignore error
-    } finally {
-      document.cookie = 'XSRF-TOKEN=;expires=Thu, 01 Jan 1970 00:00:01 GMT;';
-      window.location.reload();
-    }
-  }
-
   /**
    * gets the current sso logged in users information
    */
@@ -82,22 +71,6 @@ export class VantageSessionService {
     return response.pipe(
       map((res: HttpResponse<ISessionUser>) => {
         return res.body;
-      }),
-    );
-  }
-
-  @TdGET({
-    path: '/logout?session=true',
-    options: {
-      observe: 'response',
-    },
-  })
-  private _logout(
-    @TdResponse() response?: Observable<HttpResponse<any>>,
-  ): Observable<any> {
-    return response.pipe(
-      map((res: HttpResponse<any>) => {
-        return res;
       }),
     );
   }


### PR DESCRIPTION
## Description

### What's included?

1. Logout uses redirect instead of api call 

#### Test Steps
<!-- Add instructions on how to test your changes -->
- [ ] `npm i`
- [ ] In `proxy.conf.js` file, change serverUrl to `https://appcenter.ux.ac.uda.io`
- [ ] `npm run serve`
- [ ] Go to `localhost:4200`
- [ ] Click `Log In`
- [ ] Log in with `user1/user1`
- [ ] Click Log Out` and verify that you don't show as logged in

#### General Tests for Every PR

- [ ] `npm run serve:prod` still works.
- [ ] `npm run tslint` passes.
- [ ] `npm run stylelint` passes.
- [ ] `npm test` passes and code coverage is not lower.
- [ ] `npm run build:lib` still works.

related to https://jira.td.teradata.com/jira/browse/UDAPP-8031

##### Screenshots or link to StackBlitz/Plunker