### PR TITLE
fix: styles for surface colors & breadcrumbs

### DIFF
--- a/src/lib/_theming.scss
+++ b/src/lib/_theming.scss
@@ -506,7 +506,8 @@ $mat-dark-theme-background: map-merge(
   $mat-dark-theme-background,
   (
     card: mat-color($td-slate-dark, 600),
-    dialog: mat-color($td-slate-dark, 600)
+    dialog: mat-color($td-slate-dark, 600),
+    backdrop: mat-color($mat-grey, 800),
   )
 );
 
@@ -765,9 +766,14 @@ $mat-dark-theme-background: map-merge(
   .mat-form-field-ripple {
     background-color: if($is-dark, mat-color($primary, lighter), white);
   }
-  // Manually setting drawer backdrop to override material's deafault color invert
-  // from the card background variable
+  
+  // Manually setting drawer backdrop to override material's default color invert
+  // from the background card variable when in dark mode
+  $backdrop-background:  if($is-dark, 
+  invert(mat-color($background, backdrop, 0.6)),
+  invert(mat-color($background, card, 0.6)));
+
   .mat-drawer-backdrop.mat-drawer-shown {
-    background-color: rgba(189, 189, 189, 0.6);
+    background-color: $backdrop-background;
   }
 }

--- a/src/lib/_theming.scss
+++ b/src/lib/_theming.scss
@@ -501,6 +501,15 @@ body {
   }
 }
 
+// Overriding only the card and dialog background-colors from material dark theme
+$mat-dark-theme-background: map-merge(
+  $mat-dark-theme-background,
+  (
+    card: mat-color($td-slate-dark, 600),
+    dialog: mat-color($td-slate-dark, 600)
+  )
+);
+
 @mixin teradata-brand($theme) {
   $primary: map-get($theme, primary);
   $accent: map-get($theme, accent);
@@ -750,15 +759,15 @@ body {
       }
     }
   }
-  .mat-card, 
-  .mat-dialog-container, 
-  .mat-menu-panel {
-    background-color: if($is-dark, mat-color($td-slate-dark, 600), white);
-  }
   .td-search {
     background-color: if($is-dark, mat-color($td-slate-dark, 600), white);
   }
   .mat-form-field-ripple {
     background-color: if($is-dark, mat-color($primary, lighter), white);
+  }
+  // Manually setting drawer backdrop to override material's deafault color invert
+  // from the card background variable
+  .mat-drawer-backdrop.mat-drawer-shown {
+    background-color: rgba(189, 189, 189, 0.6);
   }
 }

--- a/src/lib/_theming.scss
+++ b/src/lib/_theming.scss
@@ -502,6 +502,8 @@ body {
 }
 
 // Overriding only the card and dialog background-colors from material dark theme
+// here. Also, we add the backdrop key as reference to the original card
+// background to be used when overriding backdrop.
 $mat-dark-theme-background: map-merge(
   $mat-dark-theme-background,
   (
@@ -767,8 +769,9 @@ $mat-dark-theme-background: map-merge(
     background-color: if($is-dark, mat-color($primary, lighter), white);
   }
   
-  // Manually setting drawer backdrop to override material's default color invert
-  // from the background card variable when in dark mode
+  // We override material backdrop to prevent the default invert on td-teal
+  // on dark-mode. If not on dark-mode, revert to original implementation
+  // inverting card background color at .6 opacity. 
   $backdrop-background:  if($is-dark, 
   invert(mat-color($background, backdrop, 0.6)),
   invert(mat-color($background, card, 0.6)));

--- a/src/lib/_theming.scss
+++ b/src/lib/_theming.scss
@@ -750,7 +750,9 @@ body {
       }
     }
   }
-  .mat-card {
+  .mat-card, 
+  .mat-dialog-container, 
+  .mat-menu-panel {
     background-color: if($is-dark, mat-color($td-slate-dark, 600), white);
   }
   .td-search {

--- a/src/lib/_theming.scss
+++ b/src/lib/_theming.scss
@@ -592,7 +592,7 @@ $mat-dark-theme-background: map-merge(
     .mat-stroked-button,
     .mat-raised-button,
     .mat-flat-button,
-    .mat-button {
+    .mat-button:not(.td-breadcrumb) {
       height: 26px;
       line-height: normal;
       .mat-button-wrapper {


### PR DESCRIPTION
Panel and dialog should have the same background as mat-card