### PR TITLE
fix: background set to bgc color

### DIFF
--- a/src/lib/_theming.scss
+++ b/src/lib/_theming.scss
@@ -683,7 +683,7 @@ $mat-dark-theme-background: map-merge(
   .tc {
     color: if($is-dark, rgba(0, 0, 0, 0.87), white);
   }
-  .bgc {
+  .bgc, td-markdown-navigator-window {
     background-color: if($is-dark, mat-color($td-slate-dark, 800), white);
   }
 


### PR DESCRIPTION
Small css fix targeting markdown navigator window so it has the same background as our default background on both dark and light mode.