### PR TITLE
fix(sso-loop): added query param to login/logout

### DIFF
--- a/src/lib/auth/guards/authentication.guard.ts
+++ b/src/lib/auth/guards/authentication.guard.ts
@@ -20,7 +20,9 @@ export class VantageAuthenticationGuard implements CanActivate {
         catchError((e: HttpErrorResponse) => {
           // if not logged in, go ahead and log in...otherwise logout
           // append the current path so we get redirected back upon login
-          e.status === UNAUTHORIZED ? (window.location.href = '/start-login') : this._sessionService.logout();
+          e.status === UNAUTHORIZED
+            ? (window.location.href = '/start-login?nonce=' + Math.floor(1000000000 + Math.random() * 9000000000))
+            : this._sessionService.logout();
           throw e;
         }),
         map(() => {

--- a/src/lib/auth/session/session.service.ts
+++ b/src/lib/auth/session/session.service.ts
@@ -56,7 +56,7 @@ export class VantageSessionService {
   }
 
   public logout(): void {
-    window.location.href = '/api/user/logout';
+    window.location.href = '/api/user/logout?nonce=' + Math.floor(1000000000 + Math.random() * 9000000000);
   }
 
   /**


### PR DESCRIPTION
## Description

[VUI-385](https://jira.td.teradata.com/jira/browse/VUI-385) - Cached page loads cause /start-login redirect loop

### What's included?

- Added query param with unique value to avoid caching during the SSO process.

#### Test Steps

- [ ] Use `ux` environment
- [ ] `npm ci`
- [ ] `npm run serve`
- [ ] Open dev tools, display Network tab
- [ ] Login and Logout and confirm query param is included on requests