### PR TITLE
fix(travis): reduce npm audit error rate

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -22,7 +22,7 @@ jobs:
     - env: 'MODE=unit-test'
     - env: 'MODE=audit'
 install:
-  - npm install
+  - npm ci
 script:
   - ./scripts/ci/travis-script.sh
 cache:

--- a/scripts/ci/travis-script.sh
+++ b/scripts/ci/travis-script.sh
@@ -40,7 +40,7 @@ elif [ "${MODE}" = "release" ]; then
 elif [ "${MODE}" = "unit-test" ]; then
   npm run test
 elif [ "${MODE}" = "audit" ]; then
-  npm audit
+  npm audit --only=prod --audit-level=high
 fi
 
 # Upload coverage results if those are present.


### PR DESCRIPTION
Change pipeline to use `npm ci` and also ignore low and moderate errors with npm audit