### PR TITLE
fix(query): temp add systems back

### DIFF
--- a/src/lib/sqle/query.service.ts
+++ b/src/lib/sqle/query.service.ts
@@ -11,6 +11,9 @@ import { map, catchError } from 'rxjs/operators';
  */
 enum SystemType {
   Teradata = 'TERADATA',
+  // TODO: remove the following 2
+  Aster = 'ASTER',
+  Presto = 'PRESTO',
 }
 interface ISystemAttributes {
   attributes?: any;


### PR DESCRIPTION
Temporarily add aster and presto systems back due to an interface clash. Will DRY up interfaces in a follow up PR.