### PR TITLE
fix(connection-service): handle empty or invalid connection session val

### DIFF
--- a/src/lib/sqle/connection.service.ts
+++ b/src/lib/sqle/connection.service.ts
@@ -9,7 +9,11 @@ export class VantageConnectionService {
   constructor(private _queryService: VantageQueryService) {}
 
   public get current(): ISQLEConnection {
-    return JSON.parse(sessionStorage.getItem(CONNECTION_SESSION_KEY));
+    try {
+      return JSON.parse(sessionStorage.getItem(CONNECTION_SESSION_KEY));
+    } catch {
+      return undefined;
+    }
   }
 
   public disconnect(): void {


### PR DESCRIPTION
Ran into a case where the ss item got set to empty.