### PR TITLE
feat(theme-service): add map method and expose observables

### DIFF
--- a/src/docs-ui/app/app.module.ts
+++ b/src/docs-ui/app/app.module.ts
@@ -62,9 +62,17 @@ import { TranslateModule, TranslateService, TranslateLoader } from '@ngx-transla
 import { getSelectedLanguage, getSelectedLocale, createTranslateLoader, SUPPORTED_LANGS } from '../config/translate';
 import { TypographyComponent } from './typography/typography.component';
 import { MatComponentsComponent, DialogContentComponent } from './mat-components/mat-components.component';
+import { DemosComponent } from './demos/demos.component';
 
 @NgModule({
-  declarations: [AppComponent, MainComponent, DialogContentComponent, TypographyComponent, MatComponentsComponent], // directives, components, and pipes owned by this NgModule
+  declarations: [
+    AppComponent,
+    MainComponent,
+    DialogContentComponent,
+    TypographyComponent,
+    MatComponentsComponent,
+    DemosComponent,
+  ], // directives, components, and pipes owned by this NgModule
   imports: [
     /** Angular Modules */
     HttpClientModule,

--- a/src/docs-ui/app/app.routes.ts
+++ b/src/docs-ui/app/app.routes.ts
@@ -6,14 +6,16 @@ import { VantageAuthenticationGuard } from '@td-vantage/ui-platform/auth';
 import { VantageBlockRootAccessGuard, VantageBlockUserAccessGuard } from '@td-vantage/ui-platform/access';
 import { TypographyComponent } from './typography/typography.component';
 import { MatComponentsComponent } from './mat-components/mat-components.component';
+import { DemosComponent } from './demos/demos.component';
 
 const routes: Routes = [
   {
     path: '',
     component: MainComponent,
     children: [
-      { path: '', redirectTo: 'components', pathMatch: 'full' },
-      { path: 'components', component: MatComponentsComponent },
+      { path: '', redirectTo: 'mat-components', pathMatch: 'full' },
+      { path: 'demos', component: DemosComponent },
+      { path: 'mat-components', component: MatComponentsComponent },
       { path: 'typography', component: TypographyComponent },
     ],
   },

--- a/src/docs-ui/app/demos/demos.component.html
+++ b/src/docs-ui/app/demos/demos.component.html
@@ -1,0 +1,7 @@
+<h2>Theme Service</h2>
+<div>Active theme: {{ _themeService.activeTheme$ | async }}</div>
+<div>Dark theme is active: {{ _themeService.darkTheme$ | async }}</div>
+<div>Light theme is active: {{ _themeService.lightTheme$ | async }}</div>
+<div>
+  Theme map: {{ _themeService.map({ 'dark-theme': 'hacker vibes 👩‍💻', 'light-theme': 'miami vibes 🏖️' }) | async }}
+</div>

--- a/src/docs-ui/app/demos/demos.component.ts
+++ b/src/docs-ui/app/demos/demos.component.ts
@@ -1,0 +1,40 @@
+import { Component, OnInit, OnDestroy } from '@angular/core';
+import { VantageThemeService } from '@td-vantage/ui-platform/theme';
+import { Subject } from 'rxjs';
+import { takeUntil } from 'rxjs/operators';
+
+@Component({
+  selector: 'app-demos',
+  templateUrl: './demos.component.html',
+  styleUrls: ['./demos.component.scss'],
+})
+export class DemosComponent implements OnInit, OnDestroy {
+  private unsubscribe: Subject<void> = new Subject();
+
+  constructor(public _themeService: VantageThemeService) {}
+
+  ngOnInit(): void {
+    // tslint:disable:no-console
+    this._themeService
+      .map({ 'dark-theme': 'dark-logo', 'light-theme': 'light-logo' })
+      .pipe(takeUntil(this.unsubscribe))
+      .subscribe(console.log);
+    this._themeService
+      .map({ 'dark-theme': 'vision', 'light-theme': 2020 })
+      .pipe(takeUntil(this.unsubscribe))
+      .subscribe(console.log);
+    this._themeService
+      .map({ 'dark-theme': 'dark-logo' }, 'fallback')
+      .pipe(takeUntil(this.unsubscribe))
+      .subscribe(console.log);
+    this._themeService.darkTheme$.pipe(takeUntil(this.unsubscribe)).subscribe(console.log);
+    this._themeService.lightTheme$.pipe(takeUntil(this.unsubscribe)).subscribe(console.log);
+    this._themeService.activeTheme$.pipe(takeUntil(this.unsubscribe)).subscribe(console.log);
+    // tslint:enable:no-console
+  }
+
+  ngOnDestroy(): void {
+    this.unsubscribe.next();
+    this.unsubscribe.complete();
+  }
+}

--- a/src/docs-ui/app/main/main.component.html
+++ b/src/docs-ui/app/main/main.component.html
@@ -8,8 +8,8 @@
       <div class="pad-md pad-bottom-none push push-bottom push-top-md">
         <mat-slide-toggle
           class="push-bottom-lg"
-          [checked]="darkThemeIsActive"
-          (change)="lightThemeIsActive ? applyDarkTheme() : applyLightTheme()"
+          [checked]="_themeService.map({ 'dark-theme': true, 'light-theme': false }) | async"
+          (change)="_themeService.toggleTheme()"
         >
           <span class="mat-input">Dark mode</span>
         </mat-slide-toggle>

--- a/src/docs-ui/app/main/main.component.ts
+++ b/src/docs-ui/app/main/main.component.ts
@@ -8,35 +8,21 @@ import { VantageThemeService } from '@td-vantage/ui-platform/theme';
   templateUrl: './main.component.html',
   styleUrls: ['./main.component.scss'],
 })
-export class MainComponent implements OnInit {
+export class MainComponent {
   navLinks: any = [
     {
-      name: 'Components',
-      route: '/components',
+      name: 'Material Components',
+      route: '/mat-components',
     },
     {
       name: 'Typography',
       route: '/typography',
     },
+    {
+      name: 'Demos',
+      route: '/demos',
+    },
   ];
 
-  constructor(private _dialog: MatDialog, private _snackbar: MatSnackBar, private _themeService: VantageThemeService) {}
-
-  ngOnInit(): void {
-    // Sets default theme to dark mode if user never set theme
-  }
-
-  get darkThemeIsActive(): boolean {
-    return this._themeService.darkThemeIsActive;
-  }
-  get lightThemeIsActive(): boolean {
-    return this._themeService.lightThemeIsActive;
-  }
-
-  applyLightTheme(): void {
-    this._themeService.applyLightTheme();
-  }
-  applyDarkTheme(): void {
-    this._themeService.applyDarkTheme();
-  }
+  constructor(private _dialog: MatDialog, private _snackbar: MatSnackBar, public _themeService: VantageThemeService) {}
 }

--- a/src/docs-ui/app/mat-components/mat-components.component.ts
+++ b/src/docs-ui/app/mat-components/mat-components.component.ts
@@ -1,4 +1,4 @@
-import { Component, OnInit } from '@angular/core';
+import { Component } from '@angular/core';
 import { MatDialog, MatDialogRef } from '@angular/material/dialog';
 import { MatSnackBar } from '@angular/material/snack-bar';
 
@@ -7,10 +7,7 @@ import { MatSnackBar } from '@angular/material/snack-bar';
   templateUrl: './mat-components.component.html',
   styleUrls: ['./mat-components.component.scss'],
 })
-export class MatComponentsComponent implements OnInit {
-  DARK_THEME: string = 'dark-theme';
-  LIGHT_THEME: string = 'light-theme';
-
+export class MatComponentsComponent {
   lastDialogResult: string;
   mode: string;
   value: number;
@@ -65,21 +62,6 @@ export class MatComponentsComponent implements OnInit {
     setInterval(() => {
       this.progress = (this.progress + Math.floor(Math.random() * 4) + 1) % 100;
     }, 200);
-  }
-
-  ngOnInit(): void {
-    // Sets default theme to dark mode if user never set theme
-    if (!this.activeTheme) {
-      this.theme(this.DARK_THEME);
-    }
-  }
-
-  get activeTheme(): string {
-    return localStorage.getItem('vantage.theme');
-  }
-  theme(theme?: string): void {
-    localStorage.setItem('vantage.theme', theme);
-    document.getElementsByTagName('body').item(0).className = theme;
   }
 
   openDialog(): void {

--- a/src/lib/theme/README.md
+++ b/src/lib/theme/README.md
@@ -1,0 +1,47 @@
+# Vantage Theme Service
+
+Exposes methods to toggle theme and observables to listen to theme changes.
+
+## Sample usage
+
+```ts
+import { VantageThemeModule } from '@td-vantage/ui-platform/theme';
+{
+  imports: [VantageThemeModule],
+};
+```
+
+Choose your weapon of choice
+
+### Within TypeScript
+
+```ts
+import { VantageThemeService } from '@td-vantage/ui-platform/theme';
+ {
+  constructor(public _themeService: VantageThemeService) {}
+
+  ngOnInit(): void {
+    this._themeService
+      .map({ 'dark-theme': 'dark-logo', 'light-theme': 'light-logo' })
+      .pipe(takeUntil(this.unsubscribe))
+      .subscribe(console.log);
+
+    this._themeService.darkTheme$.pipe(takeUntil(this.unsubscribe)).subscribe(console.log);
+    this._themeService.lightTheme$.pipe(takeUntil(this.unsubscribe)).subscribe(console.log);
+    this._themeService.activeTheme$.pipe(takeUntil(this.unsubscribe)).subscribe(console.log);
+  }
+}
+```
+
+### Within HTML
+
+```html
+<div>
+  <div>Active theme: {{ _themeService.activeTheme$ | async }}</div>
+  <div>Dark theme is active: {{ _themeService.darkTheme$ | async }}</div>
+  <div>Light theme is active: {{ _themeService.lightTheme$ | async }}</div>
+  <div>
+    Theme map: {{ _themeService.map({ 'dark-theme': 'hacker vibes 👩‍💻', 'light-theme': 'miami vibes 🏖️' }) | async }}
+  </div>
+</div>
+```


### PR DESCRIPTION
Attempting to address https://github.com/Teradata/vantage-ui-platform/issues/53

- Adds map method
  - Might want to get rid of fallback param? Added in case there are more than 2 themes at one point and might not want to specifiy values for all themes?
- Exposes more obs
- Added demos
- Added a README