### PR TITLE
Feat/theme tweaks

### DIFF
--- a/src/docs-ui/app/main/main.component.html
+++ b/src/docs-ui/app/main/main.component.html
@@ -14,7 +14,7 @@
           <span class="mat-input">Dark mode</span>
         </mat-slide-toggle>
 
-        <nav mat-tab-nav-bar color="accent" class="push-bottom-none">
+        <nav mat-tab-nav-bar class="push-bottom-none">
           <a
             mat-tab-link
             *ngFor="let link of navLinks"
@@ -23,7 +23,7 @@
             #rla="routerLinkActive"
             [active]="rla.isActive"
           >
-            {{ link.name | uppercase }}
+            {{ link.name }}
           </a>
         </nav>
       </div>

--- a/src/docs-ui/app/mat-components/mat-components.component.html
+++ b/src/docs-ui/app/mat-components/mat-components.component.html
@@ -48,11 +48,46 @@
 
     <!-- Material Chip List -->
     <div class="push-bottom-xxl pad-bottom-lg">
-      <h4 class="push-bottom-md example-h4 text-upper tc-grey-600">Material Chips</h4>
+      <h4 class="push-bottom-md example-h4 text-upper tc-grey-600">Material Chips (unselected)</h4>
 
       <mat-chip-list>
         <mat-chip>
-          Default
+          Default / Primary
+          <mat-icon matChipRemove>cancel</mat-icon>
+        </mat-chip>
+        <mat-chip color="accent">
+          Accent
+          <mat-icon matChipRemove>cancel</mat-icon>
+        </mat-chip>
+        <mat-chip color="warn">
+          Negative
+          <mat-icon matChipRemove>cancel</mat-icon>
+        </mat-chip>
+        <mat-chip color="caution">
+          Caution
+          <mat-icon matChipRemove>cancel</mat-icon>
+        </mat-chip>
+        <mat-chip color="positive">
+          Positive
+          <mat-icon matChipRemove>cancel</mat-icon>
+        </mat-chip>
+        <mat-chip color="emphasis">
+          Emphasis
+          <mat-icon matChipRemove>cancel</mat-icon>
+        </mat-chip>
+        <mat-chip color="neutral">
+          Neutral
+          <mat-icon matChipRemove>cancel</mat-icon>
+        </mat-chip>
+      </mat-chip-list>
+    </div>
+
+    <div class="push-bottom-xxl pad-bottom-lg">
+      <h4 class="push-bottom-md example-h4 text-upper tc-grey-600">Material Chips (selected)</h4>
+
+      <mat-chip-list>
+        <mat-chip selected="true">
+          Default / Primary
           <mat-icon matChipRemove>cancel</mat-icon>
         </mat-chip>
         <mat-chip color="accent" selected="true">
@@ -73,6 +108,10 @@
         </mat-chip>
         <mat-chip color="emphasis" selected="true">
           Emphasis
+          <mat-icon matChipRemove>cancel</mat-icon>
+        </mat-chip>
+        <mat-chip color="neutral" selected="true">
+          Neutral
           <mat-icon matChipRemove>cancel</mat-icon>
         </mat-chip>
       </mat-chip-list>

--- a/src/lib/theme/_default-variables.scss
+++ b/src/lib/theme/_default-variables.scss
@@ -3,11 +3,11 @@
 */
 
 // Light theme
-$td-primary: mat-palette($td-teal, 900, 100, 900);
 $td-accent: mat-palette($td-teal, 900, 100, 900);
+$td-primary: mat-palette($td-slate, 500, 200, 800);
 $td-warn: mat-palette($mat-red, 900);
 
 // Dark theme
-$td-dark-primary: mat-palette($td-teal, 300, 900, 100);
 $td-dark-accent: mat-palette($td-teal, 300, 900, 100);
+$td-dark-primary: mat-palette($td-slate, 300, 900, 200);
 $td-dark-warn: mat-palette($mat-red, 400);

--- a/src/lib/theme/_overrides.scss
+++ b/src/lib/theme/_overrides.scss
@@ -6,8 +6,7 @@
 // Radius to be used in: card, snackbar, button, dialog & menu
 $shape-radius: 8px;
 
-// Theme Config
-
+// Teradata-specific overrides
 @mixin teradata-brand($theme) {
   $primary: map-get($theme, primary);
   $accent: map-get($theme, accent);
@@ -15,6 +14,17 @@ $shape-radius: 8px;
   $background: map-get($theme, background);
   $foreground: map-get($theme, foreground);
   $is-dark: map-get($theme, is-dark);
+
+  // Component theme overrides
+  $theme--all-accent: if($is-dark, mat-dark-theme($accent, $accent, $warn), mat-light-theme($accent, $accent, $warn));
+
+  @include mat-checkbox-theme($theme--all-accent);
+  @include mat-form-field-theme($theme--all-accent);
+  @include mat-radio-theme($theme--all-accent);
+  @include mat-slide-toggle-theme($theme--all-accent);
+  @include mat-tabs-theme($theme--all-accent);
+
+  // More fine-grained overrides
 
   // Chips
   .mat-chip.mat-standard-chip {

--- a/src/lib/theme/_overrides.scss
+++ b/src/lib/theme/_overrides.scss
@@ -16,41 +16,63 @@ $shape-radius: 8px;
   $foreground: map-get($theme, foreground);
   $is-dark: map-get($theme, is-dark);
 
-  // Buttons
-  .mat-button,
-  .mat-flat-button,
-  .mat-raised-button {
-    text-transform: uppercase;
-  }
+  // Chips
+  .mat-chip.mat-standard-chip {
+    font-weight: normal;
 
-  .mat-stroked-button {
-    text-transform: uppercase;
-
-    &:not([disabled]) {
-      border-color: mat-color($foreground, icon);
+    &.mat-accent {
+      background-color: mat-color($background, accent);
+    }
+    &.mat-caution {
+      background-color: mat-color($background, caution);
+    }
+    &.mat-emphasis {
+      background-color: mat-color($background, emphasis);
+    }
+    &.mat-negative,
+    &.mat-warn {
+      background-color: mat-color($background, negative);
+    }
+    &.mat-neutral {
+      background-color: mat-color($background, neutral);
+    }
+    &.mat-positive {
+      background-color: mat-color($background, positive);
     }
     &.mat-primary {
-      border-color: mat-color($primary);
+      background-color: mat-color($background, primary);
     }
-    &.mat-accent {
-      border-color: mat-color($accent);
-    }
-    &.mat-warn {
-      border-color: mat-color($warn);
-    }
-    &:disabled {
-      border-color: map-get($foreground, disabled);
-    }
-  }
 
-  // Chips
-  .mat-chip {
-    font-weight: normal;
-  }
+    &.mat-chip-selected {
+      &.mat-accent {
+        background-color: mat-color($foreground, accent);
+        color: if($is-dark, map-get($mat-light-theme-foreground, text), map-get($mat-dark-theme-foreground, text));
+      }
+      &.mat-caution {
+        background-color: mat-color($foreground, caution);
+        color: if($is-dark, map-get($mat-light-theme-foreground, text), map-get($mat-dark-theme-foreground, text));
+      }
+      &.mat-emphasis {
+        background-color: mat-color($foreground, emphasis);
+        color: if($is-dark, map-get($mat-light-theme-foreground, text), map-get($mat-dark-theme-foreground, text));
+      }
+      &.mat-neutral {
+        background-color: mat-color($foreground, neutral);
+        color: if($is-dark, map-get($mat-light-theme-foreground, text), map-get($mat-dark-theme-foreground, text));
+      }
+      &.mat-positive {
+        background-color: mat-color($foreground, positive);
+        color: if($is-dark, map-get($mat-light-theme-foreground, text), map-get($mat-dark-theme-foreground, text));
+      }
+      &.mat-primary {
+        background-color: mat-color($foreground, primary);
+        color: if($is-dark, map-get($mat-light-theme-foreground, text), map-get($mat-dark-theme-foreground, text));
+      }
 
-  // Tabs
-  .mat-tab-label {
-    text-transform: uppercase;
+      .mat-chip-remove {
+        color: if($is-dark, map-get($mat-light-theme-foreground, icon), map-get($mat-dark-theme-foreground, icon));
+      }
+    }
   }
 
   // Active icon color in list nav
@@ -125,8 +147,61 @@ $shape-radius: 8px;
       margin-right: 8px;
     }
   }
-  // More border radius
   body {
+    // Buttons
+    a.mat-button,
+    button.mat-button,
+    .mat-flat-button {
+      // Remove min-width to make sure items align consistently
+      min-width: 0;
+      // According to the spec, non-raised buttons should have less padding
+      padding: 0 8px;
+      // According to the spec, buttons should be all-caps
+      text-transform: uppercase;
+    }
+    .mat-raised-button {
+      // According to the spec, buttons should be all-caps
+      text-transform: uppercase;
+    }
+    .mat-stroked-button {
+      // According to the spec, buttons should be all-caps
+      text-transform: uppercase;
+
+      // Update border colors to material 2 style
+      &:not([disabled]) {
+        border-color: mat-color($foreground, icon);
+      }
+      &.mat-primary {
+        border-color: mat-color($primary);
+      }
+      &.mat-accent {
+        border-color: mat-color($accent);
+      }
+      &.mat-warn {
+        border-color: mat-color($warn);
+      }
+      &:disabled {
+        border-color: map-get($foreground, disabled);
+      }
+    }
+
+    // Tabs
+    .mat-tab-link,
+    .mat-tab-label {
+      // Remove min-width to make sure items align consistently
+      min-width: 0;
+      // Match indent to buttons
+      padding: 0 16px;
+      // According to the spec, tabs should be all-caps
+      text-transform: uppercase;
+
+      // The active tab text is supposed to be darker than the rest
+      &.mat-tab-label-active {
+        opacity: 1;
+      }
+    }
+
+    // More border radius
     .mat-card,
     .mat-button-base,
     .mat-dialog-container,
@@ -152,22 +227,22 @@ $shape-radius: 8px;
   }
 
   .tc-primary {
-    color: if($is-dark, mat-color($primary), mat-color($primary));
+    color: mat-color($primary);
   }
   .tc-accent {
-    color: if($is-dark, mat-color($accent), mat-color($accent));
+    color: map-get($foreground, accent);
   }
   .tc-warn {
-    color: if($is-dark, mat-color($warn), mat-color($warn));
+    color: map-get($foreground, negative);
   }
   .bgc-primary {
-    background-color: mat-color($primary);
+    background-color: map-get($background, emphasis);
   }
   .bgc-accent {
-    background-color: mat-color($accent);
+    background-color: map-get($background, accent);
   }
   .bgc-warn {
-    background-color: mat-color($warn);
+    background-color: map-get($background, negative);
   }
   .tc-faded {
     color: if($is-dark, rgba(255, 255, 255, 0.6), rgba(0, 0, 0, 0.5));
@@ -232,7 +307,7 @@ $shape-radius: 8px;
 
   // Components
   .mat-tree {
-    background-color: if($is-dark, mat-color($td-slate-dark, 1400), $white-87-opacity);
+    background-color: transparent;
   }
   .mat-drawer-container,
   .light-theme .mat-drawer-container.mat-sidenav-container {

--- a/src/lib/theme/_palette.scss
+++ b/src/lib/theme/_palette.scss
@@ -55,7 +55,7 @@ $td-slate: (
     200: $black-87-opacity,
     300: $black-87-opacity,
     400: $black-87-opacity,
-    500: $black-87-opacity,
+    500: $white-87-opacity,
     600: $white-87-opacity,
     700: $white-87-opacity,
     800: $white-87-opacity,
@@ -152,9 +152,9 @@ $mat-light-theme-background: (
   status-bar: #e0e0e0,
   app-bar: mat-color($mat-grey, 50),
   background: mat-color($mat-grey, 200),
-  hover: rgba(0, 0, 0, 0.04),
   card: white,
   dialog: white,
+  hover: rgba(0, 0, 0, 0.04),
   disabled-button: rgba(mat-color($mat-grey, 400), 0.1),
   raised-button: white,
   focused-button: rgba(0, 0, 0, 0.12),
@@ -169,9 +169,9 @@ $mat-light-theme-background: (
   accent: mat-color($td-teal, 200),
   accent-highlight: rgba(mat-color($td-teal, 200), 0.1),
   accent-highlight-hover: rgba(mat-color($td-teal, 200), 0.2),
-  emphasis: mat-color($td-slate, 200),
-  emphasis-highlight: rgba(mat-color($td-slate, 200), 0.1),
-  emphasis-highlight-hover: rgba(mat-color($td-slate, 200), 0.2),
+  emphasis: mat-color($mat-blue-grey, 200),
+  emphasis-highlight: rgba(mat-color($mat-blue-grey, 200), 0.1),
+  emphasis-highlight-hover: rgba(mat-color($mat-blue-grey, 200), 0.2),
   caution: mat-color($mat-orange, 300),
   caution-highlight: rgba(mat-color($mat-orange, 300), 0.1),
   caution-highlight-hover: rgba(mat-color($mat-orange, 300), 0.2),
@@ -179,11 +179,14 @@ $mat-light-theme-background: (
   negative-highlight: rgba(mat-color($mat-red, 300), 0.1),
   negative-highlight-hover: rgba(mat-color($mat-red, 300), 0.2),
   neutral: mat-color($mat-grey, 400),
-  neutral-highlight: rgba(mat-color($mat-grey, 400), 0.1),
-  neutral-highlight-hover: rgba(mat-color($mat-grey, 400), 0.2),
+  neutral-highlight: rgba(mat-color($mat-grey, 400), 0.04),
+  neutral-highlight-hover: rgba(mat-color($mat-grey, 400), 0.08),
   positive: mat-color($mat-green, 200),
   positive-highlight: rgba(mat-color($mat-green, 200), 0.1),
   positive-highlight-hover: rgba(mat-color($mat-green, 200), 0.2),
+  primary: mat-color($td-slate, 200),
+  primary-highlight: rgba(mat-color($td-slate, 500), 0.04),
+  primary-highlight-hover: rgba(mat-color($td-slate, 500), 0.08),
 );
 
 // Foreground palette for light themes.
@@ -207,8 +210,9 @@ $mat-light-theme-foreground: (
   emphasis: mat-color($mat-blue-grey, 600),
   caution: mat-color($mat-amber, 800),
   negative: mat-color($mat-red, 900),
-  neutral: rgba(black, 0.87),
+  neutral: mat-color($mat-grey, 400),
   positive: mat-color($mat-green, 700),
+  primary: mat-color($td-slate, 800),
 );
 
 // Background palette for dark themes.
@@ -233,7 +237,7 @@ $mat-dark-theme-background: (
   accent: #005858,
   accent-highlight: rgba(#005858, 0.4),
   accent-highlight-hover: rgba(#005858, 0.6),
-  emphasis: mat-color($td-slate, 200),
+  emphasis: #4f5558,
   emphasis-highlight: rgba(mat-color($td-slate, 200), 0.4),
   emphasis-highlight-hover: rgba(mat-color($td-slate, 200), 0.6),
   caution: #704c16,
@@ -248,6 +252,9 @@ $mat-dark-theme-background: (
   positive: #336033,
   positive-highlight: rgba(#336033, 0.4),
   positive-highlight-hover: rgba(#336033, 0.6),
+  primary: mat-color($td-slate, 900),
+  primary-highlight: rgba(mat-color($td-slate, 900), 0.4),
+  primary-highlight-hover: rgba(mat-color($td-slate, 900), 0.6),
 );
 
 // Foreground palette for dark themes.
@@ -273,6 +280,7 @@ $mat-dark-theme-foreground: (
   negative: mat-color($mat-red, 400),
   neutral: rgba(white, 0.87),
   positive: mat-color($mat-green, 300),
+  primary: mat-color($td-slate, 200),
 );
 
 $td-positive: (

--- a/src/theme.scss
+++ b/src/theme.scss
@@ -33,6 +33,7 @@ $warn: $td-warn;
 
 // Create the theme object (a Sass map containing all of the palettes).
 $theme: mat-light-theme($primary, $accent, $warn);
+$theme-all-accent: mat-light-theme($accent, $accent, $warn);
 
 // Include theme styles for core and each component used in your app.
 // Alternatively, you can import and @include the theme mixins for each component
@@ -41,6 +42,12 @@ $theme: mat-light-theme($primary, $accent, $warn);
 @include covalent-theme($theme);
 // Include Teradata brand
 @include teradata-brand($theme);
+// Override certain component color choices
+@include mat-checkbox-theme($theme-all-accent);
+@include mat-form-field-theme($theme-all-accent);
+@include mat-radio-theme($theme-all-accent);
+@include mat-slide-toggle-theme($theme-all-accent);
+@include mat-tabs-theme($theme-all-accent);
 
 /* ------------------------------------- DARK THEME ------------------------------------------ */
 
@@ -50,9 +57,16 @@ $theme: mat-light-theme($primary, $accent, $warn);
   $dark-warn: $td-dark-warn;
 
   $dark-theme: mat-dark-theme($dark-primary, $dark-accent, $dark-warn);
+  $dark-theme-all-accent: mat-dark-theme($dark-accent, $dark-accent, $dark-warn);
 
   @include angular-material-theme($dark-theme);
   @include covalent-theme($dark-theme);
   // Include Teradata brand
   @include teradata-brand($dark-theme);
+  // Override certain component color choices
+  @include mat-checkbox-theme($dark-theme-all-accent);
+  @include mat-form-field-theme($dark-theme-all-accent);
+  @include mat-radio-theme($dark-theme-all-accent);
+  @include mat-slide-toggle-theme($dark-theme-all-accent);
+  @include mat-tabs-theme($dark-theme-all-accent);
 }

--- a/src/theme.scss
+++ b/src/theme.scss
@@ -33,7 +33,6 @@ $warn: $td-warn;
 
 // Create the theme object (a Sass map containing all of the palettes).
 $theme: mat-light-theme($primary, $accent, $warn);
-$theme-all-accent: mat-light-theme($accent, $accent, $warn);
 
 // Include theme styles for core and each component used in your app.
 // Alternatively, you can import and @include the theme mixins for each component
@@ -42,12 +41,6 @@ $theme-all-accent: mat-light-theme($accent, $accent, $warn);
 @include covalent-theme($theme);
 // Include Teradata brand
 @include teradata-brand($theme);
-// Override certain component color choices
-@include mat-checkbox-theme($theme-all-accent);
-@include mat-form-field-theme($theme-all-accent);
-@include mat-radio-theme($theme-all-accent);
-@include mat-slide-toggle-theme($theme-all-accent);
-@include mat-tabs-theme($theme-all-accent);
 
 /* ------------------------------------- DARK THEME ------------------------------------------ */
 
@@ -57,16 +50,9 @@ $theme-all-accent: mat-light-theme($accent, $accent, $warn);
   $dark-warn: $td-dark-warn;
 
   $dark-theme: mat-dark-theme($dark-primary, $dark-accent, $dark-warn);
-  $dark-theme-all-accent: mat-dark-theme($dark-accent, $dark-accent, $dark-warn);
 
   @include angular-material-theme($dark-theme);
   @include covalent-theme($dark-theme);
   // Include Teradata brand
   @include teradata-brand($dark-theme);
-  // Override certain component color choices
-  @include mat-checkbox-theme($dark-theme-all-accent);
-  @include mat-form-field-theme($dark-theme-all-accent);
-  @include mat-radio-theme($dark-theme-all-accent);
-  @include mat-slide-toggle-theme($dark-theme-all-accent);
-  @include mat-tabs-theme($dark-theme-all-accent);
 }


### PR DESCRIPTION
Update to address much of #44 

- Primary color is slate (with adaptations in light and dark for contrast)
- Accent color is teal (with adaptations in light and dark for contrast)
- Feeds different palettes to certain component themes to make 'em use the Teal (inputs, etc)

![image](https://user-images.githubusercontent.com/1143267/75172347-1c4fe700-56fb-11ea-8951-820c647716ed.png)

![image](https://user-images.githubusercontent.com/1143267/75172339-1823c980-56fb-11ea-8cd7-4e4e4cbd6526.png)


