### PR TITLE
fix(fab-buttons): propagating border radius

### DIFF
--- a/src/docs-ui/app/mat-components/mat-components.component.html
+++ b/src/docs-ui/app/mat-components/mat-components.component.html
@@ -43,6 +43,30 @@
       <button mat-icon-button disabled aria-label="Example icon-button with a heart icon">
         <mat-icon>favorite</mat-icon>
       </button>
+      <br />
+      <br />
+      <br />
+      <button class="push-sm" mat-fab>Basic</button>
+      <button class="push-sm" mat-fab color="primary">Primary</button>
+      <button class="push-sm" mat-fab color="accent">Accent</button>
+      <button class="push-sm" mat-fab color="warn">Warn</button>
+      <button class="push-sm" mat-fab disabled>Disabled</button>
+      <button class="push-sm" mat-fab aria-label="Example icon-button with a heart icon">
+        <mat-icon>favorite</mat-icon>
+      </button>
+      <a mat-fab routerLink=".">Link</a>
+      <br />
+      <br />
+      <br />
+      <button class="push-sm" mat-mini-fab>Basic</button>
+      <button class="push-sm" mat-mini-fab color="primary">Primary</button>
+      <button class="push-sm" mat-mini-fab color="accent">Accent</button>
+      <button class="push-sm" mat-mini-fab color="warn">Warn</button>
+      <button class="push-sm" mat-mini-fab disabled>Disabled</button>
+      <button class="push-sm" mat-mini-fab aria-label="Example icon-button with a heart icon">
+        <mat-icon>favorite</mat-icon>
+      </button>
+      <a mat-mini-fab routerLink=".">Link</a>
     </div>
     <!-- /Material Button -->
 

--- a/src/lib/theme/_overrides.scss
+++ b/src/lib/theme/_overrides.scss
@@ -215,7 +215,7 @@ $shape-radius: 8px;
 
     // More border radius
     .mat-card,
-    .mat-button-base,
+    .mat-button-base:not(.mat-fab):not(.mat-mini-fab),
     .mat-dialog-container,
     .mat-snack-bar-container,
     .mat-menu-panel {

--- a/src/lib/theme/_overrides.scss
+++ b/src/lib/theme/_overrides.scss
@@ -215,7 +215,7 @@ $shape-radius: 8px;
 
     // More border radius
     .mat-card,
-    .mat-button-base:not(.mat-fab):not(.mat-mini-fab),
+    .mat-button-base:not(.mat-fab):not(.mat-mini-fab):not(.mat-icon-button),
     .mat-dialog-container,
     .mat-snack-bar-container,
     .mat-menu-panel {


### PR DESCRIPTION
Adding mat fab buttons to docs and fixing the border radius bug
from #71 