### PR TITLE
feat(app-switcher): adding app switcher to bundle deployment

### DIFF
--- a/src/lib/app-switcher/app-switcher.component.ts
+++ b/src/lib/app-switcher/app-switcher.component.ts
@@ -1,5 +1,5 @@
 import { ChangeDetectionStrategy, Component, Input } from '@angular/core';
-import { VantageThemeService } from '../theme/theme.service';
+import { VantageThemeService } from '@td-vantage/ui-platform/theme';
 
 export interface IVantageAppSwitcherItem {
   text: string;

--- a/src/lib/app-switcher/app-switcher.module.ts
+++ b/src/lib/app-switcher/app-switcher.module.ts
@@ -9,7 +9,7 @@ import { CovalentMenuModule } from '@covalent/core/menu';
 
 import { TranslateModule } from '@ngx-translate/core';
 
-import { VantageThemeModule } from '../theme/theme.module';
+import { VantageThemeModule } from '@td-vantage/ui-platform/theme';
 
 import { VantageAppSwitcherComponent } from './app-switcher.component';
 

--- a/src/lib/app-switcher/index.ts
+++ b/src/lib/app-switcher/index.ts
@@ -1,2 +1,1 @@
-export * from './app-switcher.module';
-export * from './app-switcher.component';
+export * from './public_api';

--- a/src/lib/app-switcher/package.json
+++ b/src/lib/app-switcher/package.json
@@ -1,0 +1,7 @@
+{
+  "ngPackage": {
+    "lib": {
+      "entryFile": "index.ts"
+    }
+  }
+}

--- a/src/lib/app-switcher/package.json
+++ b/src/lib/app-switcher/package.json
@@ -1,7 +1,11 @@
 {
   "ngPackage": {
     "lib": {
-      "entryFile": "index.ts"
+      "entryFile": "index.ts",
+      "umdModuleIds": {
+        "@covalent/core/menu": "covalent.core.menu",
+        "@ngx-translate/core": "ngx-translate.core"
+      }
     }
   }
 }

--- a/src/lib/app-switcher/public_api.ts
+++ b/src/lib/app-switcher/public_api.ts
@@ -1,1 +1,2 @@
-export * from '.';
+export * from './app-switcher.module';
+export * from './app-switcher.component';

--- a/src/lib/app-switcher/tsconfig.json
+++ b/src/lib/app-switcher/tsconfig.json
@@ -1,9 +1,0 @@
-{
-  "extends": "../tsconfig.lib.json",
-  "compilerOptions": {
-    "paths": {
-      "@td-vantage/ui-platform": ["../"],
-      "@td-vantage/ui-platform/*": ["../*"]
-    }
-  }
-}

--- a/src/lib/app-switcher/tsconfig.json
+++ b/src/lib/app-switcher/tsconfig.json
@@ -1,0 +1,9 @@
+{
+  "extends": "../tsconfig.lib.json",
+  "compilerOptions": {
+    "paths": {
+      "@td-vantage/ui-platform": ["../"],
+      "@td-vantage/ui-platform/*": ["../*"]
+    }
+  }
+}

--- a/src/lib/sqle/package.json
+++ b/src/lib/sqle/package.json
@@ -3,7 +3,8 @@
     "lib": {
       "entryFile": "index.ts",
       "umdModuleIds": {
-        "@covalent/http": "covalent.http"
+        "@covalent/http": "covalent.http",
+        "@ngx-translate/core": "ngx-translate.core"
       }
     }
   }

--- a/src/lib/tsconfig.spec.json
+++ b/src/lib/tsconfig.spec.json
@@ -5,7 +5,11 @@
     "outDir": "../../out-tsc/spec",
     "lib": ["es6", "dom"],
     "module": "commonjs",
-    "types": ["jasmine", "hammerjs", "node"]
+    "types": ["jasmine", "hammerjs", "node"],
+    "paths": {
+      "@td-vantage/ui-platform": ["./"],
+      "@td-vantage/ui-platform/*": ["./*"]
+    }
   },
   "include": ["../polyfills.ts", "test.ts", "**/*.spec.*"]
 }


### PR DESCRIPTION
# Description
Adding the app-switcher to the ng packagr build process. and pulling theme file from `@td-vantage/ui-platform/theme` location

## Test steps

- [ ] run `ng build ui-platform`
- [ ] verify  app-switcher gets compiled down to entry point js `./deploy/ui-platform/app-switcher/`
