### PR TITLE
fix(sqle): check for log_mech and logMech on system

### DIFF
--- a/src/lib/sqle/query.service.ts
+++ b/src/lib/sqle/query.service.ts
@@ -54,7 +54,8 @@ export class VantageQueryService {
       .append('Content-Type', 'application/json');
     if (connection.creds) {
       headers = headers.set('X-Auth-Credentials', 'Basic ' + connection.creds);
-      payload.logMech = connection.system.system_attributes.attributes.log_mech || 'DEFAULT';
+      const attributes: { [key: string]: string } = connection.system.system_attributes?.attributes;
+      payload.logMech = attributes?.log_mech || attributes?.logMech || 'DEFAULT';
     } else {
       payload.logMech = 'JWT';
     }
@@ -222,7 +223,8 @@ export class VantageQueryService {
       .append('Content-Type', 'application/json');
     if (connection.creds) {
       headers = headers.set('X-Auth-Credentials', 'Basic ' + connection.creds);
-      payload.logMech = connection.system.system_attributes.attributes.log_mech || 'DEFAULT';
+      const attributes: { [key: string]: string } = connection.system.system_attributes?.attributes;
+      payload.logMech = attributes?.log_mech || attributes?.logMech || 'DEFAULT';
     } else {
       payload.logMech = 'JWT';
     }


### PR DESCRIPTION
Add an extra check in case the log mech comes as `logMech` or `log_mech` when trying to use the query service.