### PR TITLE
feat(account-profile): adding account-profile component

### DIFF
--- a/scripts/build-release
+++ b/scripts/build-release
@@ -13,6 +13,8 @@ cp -R ./src/lib/auth/config ./deploy/ui-platform/auth/
 
 # Adding theming file to ui-platform
 cp ./src/lib/app-switcher/_*.scss ./deploy/ui-platform/app-switcher/
+cp ./src/lib/account-profile/_*.scss ./deploy/ui-platform/account-profile/
+
 cp ./src/lib/theme/*.scss ./deploy/ui-platform/theme/
 cp ./src/lib/_theming.scss ./deploy/ui-platform/
 

--- a/src/docs-ui/app/app.component.html
+++ b/src/docs-ui/app/app.component.html
@@ -3,6 +3,38 @@
     <div td-toolbar-content layout="row" layout-align="start center" flex>
       <span flex></span>
 
+      <vui-account-profile name="donald duck" email="donald.duck@teradata.com">
+        <ng-container account-info-list>
+          <mat-list-item (click)="_blockEvent($event)">
+            <mat-icon matListAvatar>account_balance</mat-icon>
+            <span matLine class="mat-body-1">Default</span>
+            <span matLine>organization</span>
+          </mat-list-item>
+        </ng-container>
+        <ng-container account-action-list>
+          <button
+            mat-list-item
+            *ngIf="_themeService.lightThemeIsActive; else darkModeButton"
+            (click)="toggleTheme($event)"
+          >
+            <mat-icon matListAvatar>brightness_low</mat-icon>
+            <span matLine>Switch to dark mode</span>
+          </button>
+
+          <ng-template #darkModeButton>
+            <button mat-list-item (click)="toggleTheme($event)">
+              <mat-icon matListAvatar>brightness_high</mat-icon>
+              <span matLine>Switch to light mode</span>
+            </button>
+          </ng-template>
+          <mat-divider></mat-divider>
+          <button mat-list-item>
+            <span matListAvatar></span>
+            <span matLine>Sign out</span>
+          </button>
+        </ng-container>
+      </vui-account-profile>
+
       <vui-app-switcher
         [products]="products"
         [otherProducts]="otherProducts"

--- a/src/docs-ui/app/app.component.ts
+++ b/src/docs-ui/app/app.component.ts
@@ -74,4 +74,13 @@ export class AppComponent {
       this._domSanitizer.bypassSecurityTrustResourceUrl('assets/icons/teradata-logo.svg'),
     );
   }
+
+  toggleTheme($event: Event): void {
+    this._themeService.toggleTheme();
+  }
+
+  _blockEvent(event: Event): void {
+    event.preventDefault();
+    event.stopPropagation();
+  }
 }

--- a/src/docs-ui/app/app.module.ts
+++ b/src/docs-ui/app/app.module.ts
@@ -54,6 +54,7 @@ import { VantageAccessModule } from '@td-vantage/ui-platform/access';
 import { VantageThemeModule } from '@td-vantage/ui-platform/theme';
 import { VantageSQLEModule } from '@td-vantage/ui-platform/sqle';
 import { VantageAppSwitcherModule } from '@td-vantage/ui-platform/app-switcher';
+import { VantageAccountProfileModule } from '@td-vantage/ui-platform/account-profile';
 
 import { AppComponent } from './app.component';
 import { MainComponent } from './main/main.component';
@@ -134,6 +135,7 @@ import { CovalentComponentsComponent } from './covalent-components/covalent-comp
     VantageAccessModule,
     VantageThemeModule,
     VantageAppSwitcherModule,
+    VantageAccountProfileModule,
     VantageSQLEModule,
 
     appRoutes,

--- a/src/lib/account-profile/_account-profile-theme.scss
+++ b/src/lib/account-profile/_account-profile-theme.scss
@@ -1,0 +1,11 @@
+@mixin vantage-account-profile-theme($theme) {
+  $foreground: map-get($theme, foreground);
+  $secondary-text: map-get($foreground, secondary-text);
+
+  vui-account-profile-menu {
+    .mat-list-base .mat-list-item .mat-line:nth-child(n + 2) {
+      color: $secondary-text;
+      @include mat-typography-level-to-styles($fontConfig, caption);
+    }
+  }
+}

--- a/src/lib/account-profile/account-profile-menu/account-profile-menu.component.html
+++ b/src/lib/account-profile/account-profile-menu/account-profile-menu.component.html
@@ -1,0 +1,15 @@
+<td-menu class="account-profile-menu">
+  <!--header-->
+  <mat-list td-menu-header>
+    <mat-list-item *ngIf="name || email" (click)="_blockEvent($event)">
+      <mat-icon matListAvatar>person</mat-icon>
+      <span matLine  *ngIf="name" class="mat-body-1">{{ name }}</span>
+      <span matLine *ngIf="email">{{ email }}</span>
+    </mat-list-item>
+    <ng-content select="[account-info-list]"></ng-content>
+  </mat-list>
+  <!--content-->
+  <mat-action-list>
+    <ng-content select="[account-action-list]"></ng-content>
+  </mat-action-list>
+</td-menu>

--- a/src/lib/account-profile/account-profile-menu/account-profile-menu.component.scss
+++ b/src/lib/account-profile/account-profile-menu/account-profile-menu.component.scss
@@ -1,0 +1,35 @@
+.account-profile-menu {
+  [td-menu-header] {
+    text-align: left;
+    padding-bottom: 0;
+  }
+}
+
+::ng-deep mat-list-item:not(:first-child),
+::ng-deep [mat-list-item] {
+  .mat-list-item-content .mat-icon[matListAvatar] {
+    background: none;
+  }
+}
+
+.mat-action-list {
+  padding-top: 0;
+}
+
+::ng-deep .mat-action-list .mat-divider,
+::ng-deep .mat-divider {
+  margin: 8px 0;
+}
+
+// TODO remove styles when bug gets addressed in td-menu in Covalent
+:host ::ng-deep {
+  mat-divider:last-child {
+    display: none;
+  }
+  mat-list .mat-list-item.mat-2-line .mat-list-item-content {
+    height: inherit;
+  }
+}
+td-menu {
+  margin-bottom: 0;
+}

--- a/src/lib/account-profile/account-profile-menu/account-profile-menu.component.spec.ts
+++ b/src/lib/account-profile/account-profile-menu/account-profile-menu.component.spec.ts
@@ -1,0 +1,45 @@
+import { async, ComponentFixture, TestBed } from '@angular/core/testing';
+import { MatIconModule } from '@angular/material/icon';
+import { MatListModule } from '@angular/material/list';
+import { CovalentMenuModule } from '@covalent/core/menu';
+
+import { VantageAccountProfileMenuComponent } from './account-profile-menu.component';
+
+describe('VantageAccountProfileMenuComponent', () => {
+  let component: VantageAccountProfileMenuComponent;
+  let fixture: ComponentFixture<VantageAccountProfileMenuComponent>;
+
+  beforeEach(async(() => {
+    TestBed.configureTestingModule({
+      declarations: [VantageAccountProfileMenuComponent],
+      imports: [MatIconModule, MatListModule, CovalentMenuModule],
+    }).compileComponents();
+  }));
+
+  beforeEach(() => {
+    fixture = TestBed.createComponent(VantageAccountProfileMenuComponent);
+    component = fixture.componentInstance;
+    fixture.detectChanges();
+  });
+
+  it('should create', () => {
+    component.email = 'daffy.duck@teradata.com';
+    component.name = 'Daffy Duck';
+    fixture.detectChanges();
+
+    expect(component).toBeTruthy();
+  });
+
+  it('should block out click event on header click', () => {
+    const mouseEvent: MouseEvent = new MouseEvent("click",{bubbles: true, cancelable: true});
+
+    spyOn(mouseEvent, 'preventDefault');
+    spyOn(mouseEvent, 'stopPropagation');
+
+    component._blockEvent(mouseEvent);
+    fixture.detectChanges();
+
+    expect(mouseEvent.preventDefault).toHaveBeenCalled();
+    expect(mouseEvent.stopPropagation).toHaveBeenCalled();
+  });
+});

--- a/src/lib/account-profile/account-profile-menu/account-profile-menu.component.ts
+++ b/src/lib/account-profile/account-profile-menu/account-profile-menu.component.ts
@@ -1,0 +1,17 @@
+import { ChangeDetectionStrategy, Component, Input } from '@angular/core';
+
+@Component({
+  selector: 'vui-account-profile-menu',
+  templateUrl: './account-profile-menu.component.html',
+  styleUrls: ['./account-profile-menu.component.scss'],
+  changeDetection: ChangeDetectionStrategy.OnPush,
+})
+export class VantageAccountProfileMenuComponent {
+  @Input() email: string;
+  @Input() name: string;
+
+  _blockEvent(event: Event): void {
+    event.preventDefault();
+    event.stopPropagation();
+  }
+}

--- a/src/lib/account-profile/account-profile.component.html
+++ b/src/lib/account-profile/account-profile.component.html
@@ -1,0 +1,10 @@
+<button mat-icon-button [matMenuTriggerFor]="accountMenu">
+  <mat-icon>person</mat-icon>
+</button>
+
+<mat-menu #accountMenu="matMenu" [overlapTrigger]="false">
+  <vui-account-profile-menu [name]="name" [email]="email">
+    <ng-content select="[account-info-list]" account-info-list></ng-content>
+    <ng-content select="[account-action-list]" account-action-list></ng-content>
+  </vui-account-profile-menu>
+</mat-menu>

--- a/src/lib/account-profile/account-profile.component.spec.ts
+++ b/src/lib/account-profile/account-profile.component.spec.ts
@@ -1,0 +1,31 @@
+import { async, ComponentFixture, TestBed } from '@angular/core/testing';
+import { MatMenuModule } from '@angular/material/menu';
+import { MatIconModule } from '@angular/material/icon';
+import { MatButtonModule } from '@angular/material/button';
+import { MatListModule } from '@angular/material/list';
+import { CovalentMenuModule } from '@covalent/core/menu';
+
+import { VantageAccountProfileComponent } from './account-profile.component';
+import { VantageAccountProfileMenuComponent } from './account-profile-menu/account-profile-menu.component';
+
+describe('VantageAccountProfileComponent', () => {
+  let component: VantageAccountProfileComponent;
+  let fixture: ComponentFixture<VantageAccountProfileComponent>;
+
+  beforeEach(async(() => {
+    TestBed.configureTestingModule({
+      declarations: [VantageAccountProfileComponent, VantageAccountProfileMenuComponent],
+      imports: [MatMenuModule, MatIconModule, MatButtonModule, MatListModule, CovalentMenuModule],
+    }).compileComponents();
+  }));
+
+  beforeEach(() => {
+    fixture = TestBed.createComponent(VantageAccountProfileComponent);
+    component = fixture.componentInstance;
+    fixture.detectChanges();
+  });
+
+  it('should create', () => {
+    expect(component).toBeTruthy();
+  });
+});

--- a/src/lib/account-profile/account-profile.component.ts
+++ b/src/lib/account-profile/account-profile.component.ts
@@ -1,0 +1,11 @@
+import { ChangeDetectionStrategy, Component, Input } from '@angular/core';
+
+@Component({
+  selector: 'vui-account-profile',
+  templateUrl: './account-profile.component.html',
+  changeDetection: ChangeDetectionStrategy.OnPush,
+})
+export class VantageAccountProfileComponent {
+  @Input() name: string;
+  @Input() email: string;
+}

--- a/src/lib/account-profile/account-profile.module.ts
+++ b/src/lib/account-profile/account-profile.module.ts
@@ -1,0 +1,28 @@
+import { NgModule } from '@angular/core';
+import { CommonModule } from '@angular/common';
+import { MatMenuModule } from '@angular/material/menu';
+import { MatIconModule } from '@angular/material/icon';
+import { MatButtonModule } from '@angular/material/button';
+import { MatListModule } from '@angular/material/list';
+
+import { CovalentMenuModule } from '@covalent/core/menu';
+
+import { VantageAccountProfileMenuComponent } from './account-profile-menu/account-profile-menu.component';
+import { VantageAccountProfileComponent } from './account-profile.component';
+
+@NgModule({
+  declarations: [VantageAccountProfileComponent, VantageAccountProfileMenuComponent],
+  imports: [
+    CommonModule,
+    MatMenuModule,
+    MatIconModule,
+    MatButtonModule,
+    MatListModule,
+
+    /* covalent modules */
+    CovalentMenuModule,
+  ],
+  providers: [],
+  exports: [VantageAccountProfileComponent, VantageAccountProfileMenuComponent],
+})
+export class VantageAccountProfileModule {}

--- a/src/lib/account-profile/index.ts
+++ b/src/lib/account-profile/index.ts
@@ -1,0 +1,1 @@
+export * from './public_api';

--- a/src/lib/account-profile/package.json
+++ b/src/lib/account-profile/package.json
@@ -1,0 +1,10 @@
+{
+  "ngPackage": {
+    "lib": {
+      "entryFile": "index.ts",
+      "umdModuleIds": {
+        "@covalent/core/menu": "covalent.core.menu"
+      }
+    }
+  }
+}

--- a/src/lib/account-profile/public_api.ts
+++ b/src/lib/account-profile/public_api.ts
@@ -1,0 +1,3 @@
+export * from './account-profile.module';
+export * from './account-profile.component';
+export * from './account-profile-menu/account-profile-menu.component';

--- a/src/lib/app-switcher/app-switcher-menu/app-switcher-menu.component.spec.ts
+++ b/src/lib/app-switcher/app-switcher-menu/app-switcher-menu.component.spec.ts
@@ -6,6 +6,7 @@ import { MatMenuModule } from '@angular/material/menu';
 import { MatIconModule, MatIconRegistry } from '@angular/material/icon';
 import { MatButtonModule } from '@angular/material/button';
 import { TranslateModule } from '@ngx-translate/core';
+import { MatListModule } from '@angular/material/list';
 import { CovalentMenuModule } from '@covalent/core/menu';
 
 import { VantageThemeModule } from '../../theme/theme.module';
@@ -25,6 +26,7 @@ describe('VantageAppSwitcherMenuComponent', () => {
         MatIconModule,
         MatButtonModule,
         MatDividerModule,
+        MatListModule,
         CovalentMenuModule,
         TranslateModule.forRoot(),
         VantageThemeModule,

--- a/src/lib/app-switcher/app-switcher.component.spec.ts
+++ b/src/lib/app-switcher/app-switcher.component.spec.ts
@@ -6,6 +6,7 @@ import { MatExpansionModule } from '@angular/material/expansion';
 import { MatMenuModule } from '@angular/material/menu';
 import { MatIconModule, MatIconRegistry } from '@angular/material/icon';
 import { MatButtonModule } from '@angular/material/button';
+import { MatListModule } from '@angular/material/list';
 import { TranslateModule } from '@ngx-translate/core';
 import { CovalentMenuModule } from '@covalent/core/menu';
 
@@ -28,6 +29,7 @@ describe('VantageAppSwitcherComponent', () => {
         MatButtonModule,
         MatDividerModule,
         MatExpansionModule,
+        MatListModule,
         CovalentMenuModule,
         TranslateModule.forRoot(),
         VantageThemeModule,

--- a/src/lib/theme/_overrides.scss
+++ b/src/lib/theme/_overrides.scss
@@ -4,6 +4,7 @@
 //
 
 @import '../app-switcher/app-switcher-theme';
+@import '../account-profile/account-profile-theme';
 
 // Radius to be used in: card, snackbar, button, dialog & menu
 $shape-radius: 8px;
@@ -18,6 +19,7 @@ $shape-radius: 8px;
   $is-dark: map-get($theme, is-dark);
 
   @include vantage-app-switcher-theme($theme);
+  @include vantage-account-profile-theme($theme);
 
   // Component theme overrides
   $theme--all-accent: if($is-dark, mat-dark-theme($accent, $accent, $warn), mat-light-theme($accent, $accent, $warn));


### PR DESCRIPTION
#Description
Adding account profile component. `VantageAccountProfileModule` will include two components

1. `vui-account-profile-menu` - menu content with ng content projectors to for `account-info-list` and `account-actions-list`
2. `vui-account-profile` - icon button and mat menu setup for `vui-account-profile-menu` component

closes #75
```
<vui-account-profile name="donald duck" email="donald.duck@teradata.com">
  <ng-container account-info-list>
    <mat-list-item></mat-list-item>
  </ng-container>
  <ng-container account-action-list>
    <button mat-list-item></button>
  </ng-container>
</vui-account-profile>
```

![account-menu](https://user-images.githubusercontent.com/3837706/79019773-172ce700-7b45-11ea-8397-c79c377921b6.gif)