### PR TITLE
fix(update): update createsession method with default payload param

### DIFF
--- a/src/lib/sqle/query.service.ts
+++ b/src/lib/sqle/query.service.ts
@@ -45,6 +45,14 @@ export interface ISQLEConnection {
   creds?: string;
 }
 
+export interface ISessionPayload {
+  autoCommit: string;
+  transactionMode: string;
+  charSet: string;
+  defaultDatabase?: string;
+  logMech?: string;
+}
+
 @Injectable()
 export class VantageQueryService {
   constructor(private _http: TdHttpService) {}
@@ -213,12 +221,10 @@ export class VantageQueryService {
     );
   }
 
-  createSession(connection: ISQLEConnection): Observable<any> {
-    const payload: any = {
-      autoCommit: 'true',
-      transactionMode: 'TERA',
-      charSet: 'UTF8',
-    };
+  createSession(
+    connection: ISQLEConnection,
+    payload: ISessionPayload = { autoCommit: 'true', transactionMode: 'TERA', charSet: 'UTF8' },
+  ): Observable<any> {
     let headers: HttpHeaders = new HttpHeaders()
       .append('Accept', 'application/vnd.com.teradata.rest-v1.0+json')
       .append('Content-Type', 'application/json');


### PR DESCRIPTION
## Description

[VUI-856](https://jira.td.teradata.com/jira/browse/VUI-856) - Move create session methods from default database to ui-platform
### What's included?

- update to the createSession() method
- move the payload object and set it as a default param of the method
- created a ISessionPayload interface

#### Test Steps

- [ ] `npm ci`
- [ ] `npm run serve`
- [ ] Login and check createSession Method in query.service.ts

#### Definition of Done

- [ ] Adheres to [Covalent](https://teradata.github.io/covalent/), [Angular-Material](https://material.angular.io/) & [Material Design](https://material.io/guidelines/) patterns
- [ ] All test in i18n strings in `/src/assets/i18n/en-US.json`
- [ ] Keyboard `a11y` support (are all elements accessible through key presses)
- [ ] Resize browser to test responsive breakpoints
- [ ] `npm run test` (unit tests)
- [ ] `npm run e2e` (e2e tests)
- [ ] `npm run lint` passes (runs tslint, stylelint, prettier)
- [ ] `npm run build:prod`(AOT, product build test)

Closes [VUI-856](https://jira.td.teradata.com/jira/browse/VUI-856



##### Animated Gif (recorded with [LiceCap](https://www.cockos.com/licecap/))
<img width="808" alt="Screen Shot 2020-06-29 at 10 53 16 AM" src="https://user-images.githubusercontent.com/4431785/86039860-efd51000-b9f7-11ea-8b15-1db2c4ad03cd.png">