### PR TITLE
feat(open-apps-new-tab): modify switcher to open new tab

### DIFF
--- a/src/docs-ui/app/app.component.ts
+++ b/src/docs-ui/app/app.component.ts
@@ -44,11 +44,13 @@ export class AppComponent {
       text: 'Jupyter',
       href: 'http://teradata.com',
       icon: 'settings',
+      newTab: true,
     },
     {
       text: 'Something else',
       href: 'http://teradata.com',
       icon: 'settings',
+      newTab: false,
     },
   ];
 

--- a/src/docs-ui/app/app.component.ts
+++ b/src/docs-ui/app/app.component.ts
@@ -30,12 +30,14 @@ export class AppComponent {
     {
       text: 'App Center',
       href: 'http://teradata.com',
+      newTab: false,
     },
 
     {
       text: 'Console',
       href: 'http://teradata.com',
       icon: 'settings',
+      newTab: true,
     },
   ];
 
@@ -48,6 +50,11 @@ export class AppComponent {
     },
     {
       text: 'Something else',
+      href: 'http://teradata.com',
+      icon: 'settings',
+    },
+    {
+      text: 'Another thing',
       href: 'http://teradata.com',
       icon: 'settings',
       newTab: false,

--- a/src/lib/app-switcher/app-switcher-menu/app-switcher-menu.component.html
+++ b/src/lib/app-switcher/app-switcher-menu/app-switcher-menu.component.html
@@ -11,6 +11,7 @@
         *ngIf="product.newTab"
         mat-list-item
         class="app-switcher-list-item text-nodecoration new-tab"
+        target="_blank"
         [href]="product.href"
       >
         <mat-icon

--- a/src/lib/app-switcher/app-switcher-menu/app-switcher-menu.component.html
+++ b/src/lib/app-switcher/app-switcher-menu/app-switcher-menu.component.html
@@ -7,7 +7,7 @@
   <!--content-->
   <mat-action-list>
     <ng-container *ngFor="let product of products; last as isLast">
-      <a mat-list-item class="app-switcher-list-item text-nodecoration" target="_blank" [href]="product.href">
+      <a mat-list-item class="app-switcher-list-item text-nodecoration" [href]="product.href">
         <mat-icon
           matListAvatar
           [class]="product.iconClasses"
@@ -18,7 +18,6 @@
           <mat-icon matListAvatar [class]="product.iconClasses">{{ product.icon || 'apps' }}</mat-icon>
         </ng-template>
         <span matLine>{{ product.text }}</span>
-        <mat-icon class="text-lg" [style.margin-right.px]="0">launch</mat-icon>
       </a>
       <mat-divider class="push-top-sm push-bottom-sm" *ngIf="product.divider && !isLast"></mat-divider>
     </ng-container>
@@ -44,9 +43,12 @@
     </mat-expansion-panel-header>
     <mat-action-list [style.padding-top.px]="0">
       <ng-container *ngFor="let other of otherProducts">
-        <a mat-list-item class="text-nodecoration" target="_blank" [href]="other.href">
+        <a *ngIf="other.newTab" mat-list-item class="text-nodecoration" target="_blank" [href]="other.href">
           <span matLine>{{ other.text }}</span>
           <mat-icon class="text-lg" [style.margin-right.px]="0">launch</mat-icon>
+        </a>
+        <a *ngIf="!other.newTab" mat-list-item class="text-nodecoration" [href]="other.href">
+          <span matLine>{{ other.text }}</span>
         </a>
       </ng-container>
     </mat-action-list>

--- a/src/lib/app-switcher/app-switcher-menu/app-switcher-menu.component.html
+++ b/src/lib/app-switcher/app-switcher-menu/app-switcher-menu.component.html
@@ -43,7 +43,7 @@
     </mat-expansion-panel-header>
     <mat-action-list [style.padding-top.px]="0">
       <ng-container *ngFor="let other of otherProducts">
-        <a *ngIf="other.newTab" mat-list-item class="text-nodecoration" target="_blank" [href]="other.href">
+        <a *ngIf="other.newTab" mat-list-item class="text-nodecoration new-tab" target="_blank" [href]="other.href">
           <span matLine>{{ other.text }}</span>
           <mat-icon class="text-lg" [style.margin-right.px]="0">launch</mat-icon>
         </a>

--- a/src/lib/app-switcher/app-switcher-menu/app-switcher-menu.component.html
+++ b/src/lib/app-switcher/app-switcher-menu/app-switcher-menu.component.html
@@ -7,7 +7,25 @@
   <!--content-->
   <mat-action-list>
     <ng-container *ngFor="let product of products; last as isLast">
-      <a mat-list-item class="app-switcher-list-item text-nodecoration" [href]="product.href">
+      <a
+        *ngIf="product.newTab"
+        mat-list-item
+        class="app-switcher-list-item text-nodecoration new-tab"
+        [href]="product.href"
+      >
+        <mat-icon
+          matListAvatar
+          [class]="product.iconClasses"
+          *ngIf="product.svgIcon; else iconTemplate"
+          [svgIcon]="product.svgIcon"
+        ></mat-icon>
+        <ng-template #iconTemplate>
+          <mat-icon matListAvatar [class]="product.iconClasses">{{ product.icon || 'apps' }}</mat-icon>
+        </ng-template>
+        <span matLine>{{ product.text }}</span>
+        <mat-icon class="text-lg" [style.margin-right.px]="0">launch</mat-icon>
+      </a>
+      <a *ngIf="!product.newTab" mat-list-item class="app-switcher-list-item text-nodecoration" [href]="product.href">
         <mat-icon
           matListAvatar
           [class]="product.iconClasses"
@@ -43,11 +61,17 @@
     </mat-expansion-panel-header>
     <mat-action-list [style.padding-top.px]="0">
       <ng-container *ngFor="let other of otherProducts">
-        <a *ngIf="other.newTab" mat-list-item class="text-nodecoration new-tab" target="_blank" [href]="other.href">
+        <a
+          *ngIf="other.newTab === undefined || other.newTab === true"
+          mat-list-item
+          class="text-nodecoration new-tab"
+          target="_blank"
+          [href]="other.href"
+        >
           <span matLine>{{ other.text }}</span>
           <mat-icon class="text-lg" [style.margin-right.px]="0">launch</mat-icon>
         </a>
-        <a *ngIf="!other.newTab" mat-list-item class="text-nodecoration" [href]="other.href">
+        <a *ngIf="other.newTab === false" mat-list-item class="text-nodecoration" [href]="other.href">
           <span matLine>{{ other.text }}</span>
         </a>
       </ng-container>

--- a/src/lib/app-switcher/app-switcher-menu/app-switcher-menu.component.html
+++ b/src/lib/app-switcher/app-switcher-menu/app-switcher-menu.component.html
@@ -7,7 +7,7 @@
   <!--content-->
   <mat-action-list>
     <ng-container *ngFor="let product of products; last as isLast">
-      <a mat-list-item class="app-switcher-list-item text-nodecoration" [href]="product.href">
+      <a mat-list-item class="app-switcher-list-item text-nodecoration" target="_blank" [href]="product.href">
         <mat-icon
           matListAvatar
           [class]="product.iconClasses"
@@ -18,6 +18,7 @@
           <mat-icon matListAvatar [class]="product.iconClasses">{{ product.icon || 'apps' }}</mat-icon>
         </ng-template>
         <span matLine>{{ product.text }}</span>
+        <mat-icon class="text-lg" [style.margin-right.px]="0">launch</mat-icon>
       </a>
       <mat-divider class="push-top-sm push-bottom-sm" *ngIf="product.divider && !isLast"></mat-divider>
     </ng-container>
@@ -43,8 +44,9 @@
     </mat-expansion-panel-header>
     <mat-action-list [style.padding-top.px]="0">
       <ng-container *ngFor="let other of otherProducts">
-        <a mat-list-item class="text-nodecoration" [href]="other.href">
+        <a mat-list-item class="text-nodecoration" target="_blank" [href]="other.href">
           <span matLine>{{ other.text }}</span>
+          <mat-icon class="text-lg" [style.margin-right.px]="0">launch</mat-icon>
         </a>
       </ng-container>
     </mat-action-list>

--- a/src/lib/app-switcher/app-switcher-menu/app-switcher-menu.component.scss
+++ b/src/lib/app-switcher/app-switcher-menu/app-switcher-menu.component.scss
@@ -24,14 +24,14 @@
       padding: 0 16px;
     }
 
-    .new-tab {
-      ::ng-deep .mat-list-item-content {
-        padding-right: 12px;
-      }
-    }
-
     ::ng-deep .mat-expansion-panel-body {
       padding: 0;
+    }
+  }
+
+  .new-tab {
+    ::ng-deep .mat-list-item-content {
+      padding-right: 12px;
     }
   }
 

--- a/src/lib/app-switcher/app-switcher-menu/app-switcher-menu.component.scss
+++ b/src/lib/app-switcher/app-switcher-menu/app-switcher-menu.component.scss
@@ -23,6 +23,13 @@
     .other-products-header {
       padding: 0 16px;
     }
+
+    .new-tab {
+      ::ng-deep .mat-list-item-content {
+        padding-right: 12px;
+      }
+    }
+
     ::ng-deep .mat-expansion-panel-body {
       padding: 0;
     }

--- a/src/lib/app-switcher/services/products.service.ts
+++ b/src/lib/app-switcher/services/products.service.ts
@@ -14,6 +14,7 @@ export interface IVantageAppSwitcherItem {
   svgIcon?: string;
   iconClasses?: string[];
   divider?: boolean;
+  newTab?: boolean;
 }
 
 import { mixinHttp, TdGET } from '@covalent/http';


### PR DESCRIPTION
App switcher modified to have the following behavior:

For Vantage products, the default behavior is to switch apps within the same tab. This can be overridden by specifying newTab: true in the config.
For Other products, the default behavior is to open app in new tab. This can be overridden by specifying newTab: false in the config.

![Screen Shot 2020-06-30 at 3 51 12 PM](https://user-images.githubusercontent.com/546264/86184927-03f93a00-baea-11ea-96dc-da56f35d4ada.png)
