### PR TITLE
Feat/querybands - support querybands on session and query APIs

### DIFF
--- a/src/lib/sqle/query.service.ts
+++ b/src/lib/sqle/query.service.ts
@@ -74,6 +74,13 @@ export enum QueryResultColumnTypes {
   'VARIANT_TYPE' = 'VARIANT_TYPE',
 }
 
+export interface IQueryBands {
+  ApplicationName: string;
+  Version: string;
+  ClientUser?: string;
+  [name: string]: string;
+}
+
 export interface IQueryPayload {
   query: string;
   session?: string;
@@ -86,7 +93,7 @@ export interface IQueryPayload {
   outputNumbersAsStrings?: boolean;
   spooledResultSet?: boolean;
   clientId?: string;
-  queryBands?: string;
+  queryBands?: IQueryBands;
 }
 
 export interface IQueryResultSet {
@@ -130,7 +137,7 @@ export interface ISessionPayload {
   charSet: string;
   defaultDatabase?: string;
   logMech?: string;
-  queryBands?: string;
+  queryBands?: IQueryBands;
 }
 
 @Injectable()

--- a/src/lib/sqle/query.service.ts
+++ b/src/lib/sqle/query.service.ts
@@ -86,6 +86,7 @@ export interface IQueryPayload {
   outputNumbersAsStrings?: boolean;
   spooledResultSet?: boolean;
   clientId?: string;
+  queryBands?: string;
 }
 
 export interface IQueryResultSet {
@@ -129,6 +130,7 @@ export interface ISessionPayload {
   charSet: string;
   defaultDatabase?: string;
   logMech?: string;
+  queryBands?: string;
 }
 
 @Injectable()


### PR DESCRIPTION
QueryBands is an optional property on the ISessionPayload and IQueryPayload objects. The QueryBands property is a map, with reasonable default name/value pairs of ApplicationName, Version and ClientUser. Additional name/value pairs can be specified as appropriate for the application utilizing the API.