### PR TITLE
feat(user-profile): Theme toggle improvements

### DIFF
--- a/src/lib/user-profile/user-profile.component.html
+++ b/src/lib/user-profile/user-profile.component.html
@@ -5,9 +5,9 @@
   matTooltipShowDelay="0"
 >
   <ng-container td-user-action-list>
-    <button mat-list-item (click)="themeService.toggleTheme()">
+    <button mat-list-item (click)="themeService.toggleTheme(); $event.stopPropagation()">
       <mat-icon matListAvatar>
-        {{ themeService.map({ 'dark-theme': 'brightness_high', 'light-theme': 'brightness_low' }) | async }}
+        {{ themeService.map({ 'dark-theme': 'wb_sunny', 'light-theme': 'brightness_2' }) | async }}
       </mat-icon>
       <span matLine>
         {{


### PR DESCRIPTION
Hi,

Used more natural (and intuitive) icons for the light and dark modes. And made it so the dropdown doesn't close on changing the theme since users often want to quickly toggle and check between the two modes (like myself).

**Before:**

![user-profile-menu-before](https://user-images.githubusercontent.com/36920441/92449471-8f223a80-f1d3-11ea-9ddd-248a2dea9fd2.gif)

**After:**

![user-profile-menu-after](https://user-images.githubusercontent.com/36920441/92449463-8b8eb380-f1d3-11ea-8a90-90f66558630c.gif)

Let me know if this is undesired. :)

Thanks.